### PR TITLE
fix: improve cross-origin image loading

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -48,7 +48,7 @@ class CanvasImage {
 }
 
 class ColorThief extends Core {
-  private crossOrigin: Boolean;
+  private crossOrigin: boolean;
 
   constructor(opts?: { crossOrigin: boolean }) {
     super();
@@ -56,13 +56,8 @@ class ColorThief extends Core {
   }
 
   private async asyncFetchImage(imageUrl: string) {
-    const imageSource = await fetch(imageUrl, {
-      method: "GET",
-      headers: this.crossOrigin
-        ? { "Access-Control-Allow-Origin": "*" }
-        : undefined,
-    })
-      .then(function (response) {
+    const imageSource = await fetch(imageUrl, { mode: "cors" })
+      .then((response) => {
         // Check if the request was successful
         if (response.ok) {
           // Convert the response to a blob (binary data)
@@ -71,13 +66,19 @@ class ColorThief extends Core {
 
         return null;
       })
-      .then(function (blob) {
+      .then((blob) => {
         // Create an image element from the blob data
+        if (blob === null) {
+          return null;
+        }
         const img = document.createElement("img");
-        img.src = URL.createObjectURL(blob as Blob);
+        if (this.crossOrigin) {
+          img.crossOrigin = "anonymous";
+        }
+        img.src = URL.createObjectURL(blob);
         return img;
       })
-      .catch(function (error) {
+      .catch(() => {
         // Handle any errors
         return null;
       });


### PR DESCRIPTION
## Summary
- use primitive `boolean` for crossOrigin flag
- simplify async image loading with CORS mode and optional `crossOrigin` attribute

## Testing
- `yarn build:browser`
- `node -e "fetch('https://via.placeholder.com/150', {mode:'cors'}).then(res=>console.log('status', res.status)).catch(err=>console.error('error', err))"` *(fails: getaddrinfo ENOTFOUND via.placeholder.com)*

------
https://chatgpt.com/codex/tasks/task_e_689a3f6f39ec8326947884ed3f24b5ca