### PR TITLE
Handle color type conversion in core

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "build": "yarn  build:browser && yarn build:node",
     "build:browser": "tsup src/browser.ts --format esm,cjs --dts",
     "build:node": "tsup src/node.ts --format esm,cjs --dts",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test test/core.test.cjs"
   },
   "repository": {
     "type": "git",

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,7 +1,6 @@
 // color quantization, based on Leptonica
 import Core from "./core";
 import type { ColorArray, PaletteOptions } from "./type";
-import arrayToHex from "./utils/arrayToHex";
 
 /**
  *
@@ -134,17 +133,8 @@ class ColorThief extends Core {
     colorCount: number,
     opts?: PaletteOptions
   ) {
-    const colorType = opts?.colorType ?? "hex";
-
     const [imageData, pixelCount] = this.getImageData(sourceImage);
-
-    const palette = this._getPalette(imageData, pixelCount, colorCount, opts);
-
-    if (colorType === "hex") {
-      return palette.map((item) => arrayToHex(item));
-    }
-
-    return palette;
+    return this._getPalette(imageData, pixelCount, colorCount, opts);
   }
 
   /*
@@ -171,23 +161,8 @@ class ColorThief extends Core {
   ): string;
 
   public getColor(sourceImage: HTMLImageElement, opts?: PaletteOptions) {
-    const colorType = opts?.colorType ?? "hex";
-
-    const palette = this.getPalette(sourceImage, 5, {
-      quality: opts?.quality ?? DEFAULT_QUALITY,
-      colorType: "array",
-    });
-    const dominantColor = palette?.[0] ?? null;
-
-    if (dominantColor === null) {
-      return dominantColor;
-    }
-
-    if (colorType === "hex") {
-      return arrayToHex(dominantColor);
-    }
-
-    return dominantColor;
+    const [imageData, pixelCount] = this.getImageData(sourceImage);
+    return this._getColor(imageData, pixelCount, opts);
   }
 
   public getPaletteAsync(
@@ -208,27 +183,16 @@ class ColorThief extends Core {
     opts?: PaletteOptions
   ) {
     const quality = opts?.quality ?? DEFAULT_QUALITY;
-    const colorType = opts?.colorType ?? "hex";
 
     return this.asyncFetchImage(imageUrl).then((sourceImage) => {
       if (sourceImage === null) {
         return { dominantColor: null, palette: [], image: sourceImage };
       }
 
-      const palette = this.getPalette(sourceImage, colorCount, {
+      return this.getPalette(sourceImage, colorCount, {
         quality,
-        colorType: "array",
+        colorType: opts?.colorType,
       });
-
-      if (palette === null) {
-        return { dominantColor: null, palette: [], image: sourceImage };
-      }
-
-      if (colorType === "hex") {
-        return palette.map((item) => arrayToHex(item));
-      }
-
-      return palette;
     });
   }
 
@@ -244,29 +208,16 @@ class ColorThief extends Core {
 
   public getColorAsync(imageUrl: string, opts?: PaletteOptions) {
     const quality = opts?.quality ?? DEFAULT_QUALITY;
-    const colorType = opts?.colorType ?? "hex";
 
     return this.asyncFetchImage(imageUrl).then((sourceImage) => {
       if (sourceImage === null) {
         return { dominantColor: null, palette: [], image: sourceImage };
       }
 
-      const palette = this.getPalette(sourceImage, 5, {
+      return this.getColor(sourceImage, {
         quality,
-        colorType: "array",
+        colorType: opts?.colorType,
       });
-
-      if (palette === null) {
-        return { dominantColor: null, palette: [], image: sourceImage };
-      }
-
-      const dominantColor = palette[0];
-
-      if (colorType === "hex") {
-        return arrayToHex(dominantColor);
-      }
-
-      return dominantColor;
     });
   }
 }

--- a/src/core.ts
+++ b/src/core.ts
@@ -2,15 +2,8 @@
 import quantize from "quantize";
 import createPixelArray from "./utils/createPixelArray";
 import validateOptions from "./utils/validateOptions";
-
-type ColorArray = [number, number, number];
-
-type ColorType = "array" | "hex";
-
-interface PaletteOptions<T extends ColorType = ColorType> {
-  quality?: number;
-  colorType?: T;
-}
+import arrayToHex from "./utils/arrayToHex";
+import type { ColorArray, PaletteOptions, ColorType } from "./type";
 
 /**
  *
@@ -47,13 +40,13 @@ class ColorThief {
    *
    *
    */
-  protected _getPalette(
+  protected _getPalette<T extends ColorType = "hex">(
     imageData: ImageData,
     pixelCount: number,
     colorCount: number,
-    opts?: PaletteOptions
-  ) {
-    const colorType = opts?.colorType ?? "hex";
+    opts?: PaletteOptions<T>
+  ): T extends "hex" ? string[] : ColorArray[] {
+    const colorType = (opts?.colorType ?? "hex") as ColorType;
 
     const options = validateOptions({
       colorCount,
@@ -71,7 +64,11 @@ class ColorThief {
     const cmap = quantize(pixelArray, options.colorCount);
     const palette = cmap ? (cmap.palette() as ColorArray[]) : [];
 
-    return palette;
+    if (colorType === "hex") {
+      return palette.map((color) => arrayToHex(color)) as any;
+    }
+
+    return palette as any;
   }
 
   /*
@@ -87,23 +84,19 @@ class ColorThief {
    * most dominant color.
    *
    * */
-  protected _getColor(
+  protected _getColor<T extends ColorType = "hex">(
     imageData: ImageData,
     pixelCount: number,
-    opts?: PaletteOptions
-  ) {
-    const colorType = opts?.colorType ?? "hex";
-
+    opts?: PaletteOptions<T>
+  ): (T extends "hex" ? string : ColorArray) | null {
     const palette = this._getPalette(imageData, pixelCount, 5, {
       quality: opts?.quality ?? DEFAULT_QUALITY,
-      colorType: "array",
-    });
-    const dominantColor = palette?.[0] ?? null;
+      colorType: opts?.colorType,
+    } as PaletteOptions<T>);
 
-    if (dominantColor === null) {
-      return dominantColor;
-    }
-    return dominantColor;
+    const dominantColor = (palette as any)?.[0] ?? null;
+
+    return dominantColor ?? null;
   }
 }
 

--- a/src/node.ts
+++ b/src/node.ts
@@ -2,7 +2,6 @@
 import getPixels from "get-pixels";
 import Core from "./core";
 import type { ColorArray, PaletteOptions } from "./type";
-import arrayToHex from "./utils/arrayToHex";
 
 /**
  *
@@ -52,8 +51,6 @@ class ColorThief extends Core {
   ): Promise<string[]>;
 
   public getPalette(img: ImageType, colorCount = 10, opts?: PaletteOptions) {
-    const colorType = opts?.colorType ?? "hex";
-
     return new Promise((resolve, reject) => {
       this.getImageData(img)
         .then(([imageData, pixelCount]) => {
@@ -64,11 +61,7 @@ class ColorThief extends Core {
             opts
           );
 
-          if (colorType === "hex") {
-            return resolve(palette.map((item) => arrayToHex(item)));
-          }
-
-          return resolve(palette);
+          resolve(palette);
         })
         .catch((err) => {
           reject(err);
@@ -84,19 +77,11 @@ class ColorThief extends Core {
   public getColor(img: ImageType, opt?: PaletteOptions<"hex">): Promise<string>;
 
   public getColor(img: ImageType, opts?: PaletteOptions) {
-    const colorType = opts?.colorType ?? "hex";
-
     return new Promise((resolve, reject) => {
-      this.getPalette(img, 5, {
-        quality: opts?.quality ?? 10,
-        colorType: "array",
-      })
-        .then((palette) => {
-          if (colorType === "hex") {
-            return resolve(arrayToHex(palette[0]));
-          }
-
-          return resolve(palette[0]);
+      this.getImageData(img)
+        .then(([imageData, pixelCount]) => {
+          const color = this._getColor(imageData, pixelCount, opts);
+          resolve(color as any);
         })
         .catch((err) => {
           reject(err);

--- a/test/core.test.cjs
+++ b/test/core.test.cjs
@@ -1,0 +1,71 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const ts = require('typescript');
+
+require.extensions['.ts'] = function (module, filename) {
+  const source = fs.readFileSync(filename, 'utf8');
+  const { outputText } = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2019,
+      esModuleInterop: true,
+    },
+  });
+  module._compile(outputText, filename);
+};
+
+const Core = require('../src/core.ts').default;
+
+class TestCore extends Core {
+  palette(imageData, pixelCount, colorCount, opts) {
+    return this._getPalette(imageData, pixelCount, colorCount, opts);
+  }
+  color(imageData, pixelCount, opts) {
+    return this._getColor(imageData, pixelCount, opts);
+  }
+}
+
+const core = new TestCore();
+
+const red = [255, 0, 0, 255];
+const blue = [0, 0, 255, 255];
+
+const paletteData = {
+  data: new Uint8ClampedArray([...red, ...blue]),
+  width: 2,
+  height: 1,
+};
+
+const colorData = {
+  data: new Uint8ClampedArray([...red, ...red, ...blue]),
+  width: 3,
+  height: 1,
+};
+
+describe('Core palette', () => {
+  it('returns hex colors by default', () => {
+    const result = core.palette(paletteData, 2, 2);
+    assert.ok(result.length >= 1);
+    assert.ok(typeof result[0] === 'string');
+  });
+
+  it('returns array colors when colorType is array', () => {
+    const result = core.palette(paletteData, 2, 2, { colorType: 'array' });
+    assert.ok(result.length >= 1);
+    assert.ok(Array.isArray(result[0]));
+  });
+});
+
+describe('Core dominant color', () => {
+  it('returns hex color by default', () => {
+    const result = core.color(colorData, 3);
+    assert.ok(typeof result === 'string');
+  });
+
+  it('returns array when colorType is array', () => {
+    const result = core.color(colorData, 3, { colorType: 'array' });
+    assert.ok(Array.isArray(result));
+    assert.strictEqual(result.length, 3);
+  });
+});


### PR DESCRIPTION
## Summary
- Convert palette and dominant color results to hex or array in core so callers don't need to handle conversion
- Simplify browser and node adapters to rely on core for color type selection
- Add basic tests exercising hex and array outputs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a4147a65c832690b454111f8e7b78