### PR TITLE
Handle async color failures with null responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,13 @@ const colorThief = new ColorThief();
 const dominantColor = await colorThief.getColorAsync("your-domaon/your-image-url.jpg");
 const palette = await colorThief.getPaletteAsync("your-domaon/your-image-url.jpg", 5);
 
-console.log(dominantColor);
-console.log(palette);
+if (dominantColor) {
+  console.log(dominantColor);
+}
+
+if (palette) {
+  console.log(palette);
+}
 ```
 
 ### example for node.js

--- a/example/colorThief/browser.ts
+++ b/example/colorThief/browser.ts
@@ -194,13 +194,13 @@ class ColorThief extends Core {
     imageUrl: string,
     colorCount: number,
     opts?: PaletteOptions<"array">
-  ): Promise<ColorArray[]>;
+  ): Promise<ColorArray[] | null>;
 
   public getPaletteAsync(
     imageUrl: string,
     colorCount: number,
     opts?: PaletteOptions<"hex">
-  ): Promise<string[]>;
+  ): Promise<string[] | null>;
 
   public getPaletteAsync(
     imageUrl: string,
@@ -212,7 +212,7 @@ class ColorThief extends Core {
 
     return this.asyncFetchImage(imageUrl).then((sourceImage) => {
       if (sourceImage === null) {
-        return { dominantColor: null, palette: [], image: sourceImage };
+        return null;
       }
 
       const palette = this.getPalette(sourceImage, colorCount, {
@@ -220,8 +220,8 @@ class ColorThief extends Core {
         colorType: "array",
       });
 
-      if (palette === null) {
-        return { dominantColor: null, palette: [], image: sourceImage };
+      if (palette.length === 0) {
+        return null;
       }
 
       if (colorType === "hex") {
@@ -235,12 +235,12 @@ class ColorThief extends Core {
   public getColorAsync(
     imageUrl: string,
     opts?: PaletteOptions<"array">
-  ): Promise<ColorArray>;
+  ): Promise<ColorArray | null>;
 
   public getColorAsync(
     imageUrl: string,
     opts?: PaletteOptions<"hex">
-  ): Promise<string>;
+  ): Promise<string | null>;
 
   public getColorAsync(imageUrl: string, opts?: PaletteOptions) {
     const quality = opts?.quality ?? DEFAULT_QUALITY;
@@ -248,7 +248,7 @@ class ColorThief extends Core {
 
     return this.asyncFetchImage(imageUrl).then((sourceImage) => {
       if (sourceImage === null) {
-        return { dominantColor: null, palette: [], image: sourceImage };
+        return null;
       }
 
       const palette = this.getPalette(sourceImage, 5, {
@@ -256,8 +256,8 @@ class ColorThief extends Core {
         colorType: "array",
       });
 
-      if (palette === null) {
-        return { dominantColor: null, palette: [], image: sourceImage };
+      if (palette.length === 0) {
+        return null;
       }
 
       const dominantColor = palette[0];

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "build": "yarn  build:browser && yarn build:node",
     "build:browser": "tsup src/browser.ts --format esm,cjs --dts",
     "build:node": "tsup src/node.ts --format esm,cjs --dts",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test"
   },
   "repository": {
     "type": "git",

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -195,13 +195,13 @@ class ColorThief extends Core {
     imageUrl: string,
     colorCount: number,
     opts?: PaletteOptions<"array">
-  ): Promise<ColorArray[]>;
+  ): Promise<ColorArray[] | null>;
 
   public getPaletteAsync(
     imageUrl: string,
     colorCount: number,
     opts?: PaletteOptions<"hex">
-  ): Promise<string[]>;
+  ): Promise<string[] | null>;
 
   public getPaletteAsync(
     imageUrl: string,
@@ -213,7 +213,7 @@ class ColorThief extends Core {
 
     return this.asyncFetchImage(imageUrl).then((sourceImage) => {
       if (sourceImage === null) {
-        return { dominantColor: null, palette: [], image: sourceImage };
+        return null;
       }
 
       const palette = this.getPalette(sourceImage, colorCount, {
@@ -221,8 +221,8 @@ class ColorThief extends Core {
         colorType: "array",
       });
 
-      if (palette === null) {
-        return { dominantColor: null, palette: [], image: sourceImage };
+      if (palette.length === 0) {
+        return null;
       }
 
       if (colorType === "hex") {
@@ -236,12 +236,12 @@ class ColorThief extends Core {
   public getColorAsync(
     imageUrl: string,
     opts?: PaletteOptions<"array">
-  ): Promise<ColorArray>;
+  ): Promise<ColorArray | null>;
 
   public getColorAsync(
     imageUrl: string,
     opts?: PaletteOptions<"hex">
-  ): Promise<string>;
+  ): Promise<string | null>;
 
   public getColorAsync(imageUrl: string, opts?: PaletteOptions) {
     const quality = opts?.quality ?? DEFAULT_QUALITY;
@@ -249,7 +249,7 @@ class ColorThief extends Core {
 
     return this.asyncFetchImage(imageUrl).then((sourceImage) => {
       if (sourceImage === null) {
-        return { dominantColor: null, palette: [], image: sourceImage };
+        return null;
       }
 
       const palette = this.getPalette(sourceImage, 5, {
@@ -257,8 +257,8 @@ class ColorThief extends Core {
         colorType: "array",
       });
 
-      if (palette === null) {
-        return { dominantColor: null, palette: [], image: sourceImage };
+      if (palette.length === 0) {
+        return null;
       }
 
       const dominantColor = palette[0];

--- a/test/browser.test.js
+++ b/test/browser.test.js
@@ -1,0 +1,34 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import ColorThief from '../dist/browser.js';
+
+test('getPaletteAsync resolves palette on success', async () => {
+  const ct = new ColorThief();
+  ct.getPalette = () => [[1, 2, 3]];
+  ct.asyncFetchImage = () => Promise.resolve({});
+  const palette = await ct.getPaletteAsync('url', 5, { colorType: 'array' });
+  assert.deepStrictEqual(palette, [[1, 2, 3]]);
+});
+
+test('getPaletteAsync returns null on failure', async () => {
+  const ct = new ColorThief();
+  ct.asyncFetchImage = () => Promise.resolve(null);
+  const palette = await ct.getPaletteAsync('url', 5, { colorType: 'array' });
+  assert.strictEqual(palette, null);
+});
+
+test('getColorAsync resolves color on success', async () => {
+  const ct = new ColorThief();
+  ct.getPalette = () => [[1, 2, 3]];
+  ct.asyncFetchImage = () => Promise.resolve({});
+  const color = await ct.getColorAsync('url', { colorType: 'array' });
+  assert.deepStrictEqual(color, [1, 2, 3]);
+});
+
+test('getColorAsync returns null on failure', async () => {
+  const ct = new ColorThief();
+  ct.getPalette = () => [];
+  ct.asyncFetchImage = () => Promise.resolve({});
+  const color = await ct.getColorAsync('url', { colorType: 'array' });
+  assert.strictEqual(color, null);
+});


### PR DESCRIPTION
## Summary
- Update `getPaletteAsync` and `getColorAsync` to return `null` on failure instead of custom objects
- Adjust return types and examples to handle nullable results
- Add tests covering success and failure cases for async APIs

## Testing
- `npm run build:browser`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a4423dc908326bbf1682b19fbd736